### PR TITLE
Removed invisible dead blocks

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -51,7 +51,7 @@ function draw() {
                     for (let j = 0; j < gameHeight; j++) {
                         column.push(null);
                     }
-                    deadBlocksMatrix.push(column);
+                    deadBlocksMatrix[i]=column;
                 }
                 deadBlocks = [];
                 currentShape = new Shape(getRandomShapeID(), createVector(floor(random(1, gameWidth - 2)), 0));


### PR DESCRIPTION
When the blocks reach the top and the player/program dies, the dead blocks aren't cleared, which makes the blocks start to accumulate